### PR TITLE
Convert times less than a second into milliseconds

### DIFF
--- a/lib/kbn.js
+++ b/lib/kbn.js
@@ -264,7 +264,12 @@ kbn.valueFormats.s = function(size, decimals, scaledDecimals) {
     return {};
   }
 
-  if (Math.abs(size) < 60) {
+  // Less than 1 s, multiply into milliseconds
+  if (Math.abs(size) < 1) {
+    return kbn.toFixedScaled(size * 1000, decimals, scaledDecimals, 2, 'ms');
+  }
+
+  else if (Math.abs(size) < 60) {
     return {value: kbn.toFixed(size, decimals), symbol:'s'};
   }
   // Less than 1 hour, devide in minutes

--- a/test/test.js
+++ b/test/test.js
@@ -24,6 +24,7 @@ describe('Time', function() {
     testFormatValue('ms', 651500000, '7.541 day');
   });
   describe('Seconds', function() {
+    testFormatValue('s', 0.0245, '24.5 ms');
     testFormatValue('s', 24, '24 s');
     testFormatValue('s', 246, '4.1 min');
     testFormatValue('s', 24567, '6.824 hr');


### PR DESCRIPTION
Add better support for very small times using default units of seconds.
