### PR TITLE
Add kBps, mBps, and gBps data rates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ Supported unit codes recognized by the formatValue api call.
   <tr>
     <td>Bps</td><td>bytes/sec</td>
   </tr>
+  <tr>
+    <td>kBps</td><td>kilobytes/sec</td>
+  </tr>
+  <tr>
+    <td>mBps</td><td>megabytes/sec</td>
+  </tr>
+  <tr>
+    <td>gBps</td><td>gigabytes/sec</td>
+  </tr>
 
   <tr>
     <td colspan="3"><div align="center"><em>time</em></div></td>

--- a/lib/kbn.js
+++ b/lib/kbn.js
@@ -182,6 +182,9 @@ kbn.valueFormats.gbytes = kbn.formatBuilders.binarySIPrefix('B', 3);
 kbn.valueFormats.pps = kbn.formatBuilders.decimalSIPrefix('pps');
 kbn.valueFormats.bps = kbn.formatBuilders.decimalSIPrefix('bps');
 kbn.valueFormats.Bps = kbn.formatBuilders.decimalSIPrefix('Bps');
+kbn.valueFormats.kBps = kbn.formatBuilders.decimalSIPrefix('Bps', 1);
+kbn.valueFormats.mBps = kbn.formatBuilders.decimalSIPrefix('Bps', 2);
+kbn.valueFormats.gBps = kbn.formatBuilders.decimalSIPrefix('Bps', 3);
 
 // Throughput
 kbn.valueFormats.ops = kbn.formatBuilders.simpleCountUnit('ops');


### PR DESCRIPTION
[sar](http://linux.die.net/man/1/sar) reports network traffic as kbps so I added `kBps` and while I was at it `mBps` and `gBps` too.
